### PR TITLE
Remove `backports.tempfile` for newer Python dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9e16bfe3f635e65d8725232f213a046fedda46f78b5b330fb2e33563eebff685
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - cytominer-database=cytominer_database.command:command
@@ -19,7 +19,6 @@ build:
 requirements:
   host:
     - python >=3.4
-    - backports.tempfile >=1.0rc1
     - click >=6.7
     - configparser >=3.5.0
     - csvkit >=1.0.2
@@ -29,7 +28,6 @@ requirements:
     - setuptools
   run:
     - python >=3.4
-    - backports.tempfile >=1.0rc1
     - click >=6.7
     - configparser >=3.5.0
     - csvkit >=1.0.2


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Relates to https://github.com/conda-forge/pycytominer-feedstock/pull/11 , where we found that Pycytominer conda builds were failing `pip check` with Python 3.10.15 due to `backports.tempfile` as a dependency from `cytominer-database`. As a result, we remove `backports.tempfile` here with a new build to help address the changes moving forward. Please note: [`cytominer-database` is deprecated](https://github.com/cytomining/cytominer-database).